### PR TITLE
Fix blocked webpage fetches with a requests fallback

### DIFF
--- a/scripts/search/bing_search.py
+++ b/scripts/search/bing_search.py
@@ -14,7 +14,7 @@ import string
 from typing import Optional, Tuple
 from nltk.tokenize import sent_tokenize
 from typing import List, Dict, Union
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 import aiohttp
 import asyncio
 import chardet
@@ -36,6 +36,21 @@ headers = {
     'Connection': 'keep-alive',
     'Upgrade-Insecure-Requests': '1'
 }
+
+WIKIMEDIA_USER_AGENT = (
+    'WebThinkerResearchBot/0.1 '
+    '(https://github.com/RUC-NLPIR/WebThinker; academic research)'
+)
+
+
+def request_headers_for_url(url: str) -> Dict[str, str]:
+    request_headers = dict(headers)
+    hostname = (urlparse(url).hostname or '').lower()
+    if hostname.endswith(('.wikipedia.org', '.wikimedia.org', '.wikimediafoundation.org')):
+        request_headers['User-Agent'] = WIKIMEDIA_USER_AGENT
+        request_headers.pop('Referer', None)
+    return request_headers
+
 
 # Initialize session
 session = requests.Session()
@@ -179,7 +194,11 @@ def extract_text_from_url(url, use_jina=False, jina_api_key=None, snippet: Optio
                 return extract_pdf_text(url)
 
             try:
-                response = session.get(url, timeout=30)
+                response = session.get(
+                    url,
+                    timeout=30,
+                    headers=request_headers_for_url(url),
+                )
                 response.raise_for_status()
                 
                 # 添加编码检测和处理
@@ -196,8 +215,7 @@ def extract_text_from_url(url, use_jina=False, jina_api_key=None, snippet: Optio
                 has_error = (any(indicator.lower() in response.text.lower() for indicator in error_indicators) and len(response.text.split()) < 64) or response.text == ''
                 if has_error:
                     if WebParserClient_url is None:
-                        # If WebParserClient is not available, return error message
-                        return f"Error extracting content: {str(e)}"
+                        return f"Error extracting content: empty or blocked response from {url}"
                     # If content has error, use WebParserClient as fallback
                     client = WebParserClient(WebParserClient_url)
                     results = client.parse_urls([url])
@@ -502,6 +520,23 @@ class RateLimiter:
 # 创建全局速率限制器实例
 jina_rate_limiter = RateLimiter(rate_limit=130)  # 每分钟xxx次，避免报错
 
+async def fetch_with_requests_fallback(
+    url: str,
+    use_jina: bool = False,
+    jina_api_key: Optional[str] = None,
+    snippet: Optional[str] = None,
+    keep_links: bool = False,
+) -> str:
+    return await asyncio.to_thread(
+        extract_text_from_url,
+        url,
+        use_jina,
+        jina_api_key,
+        snippet,
+        keep_links,
+    )
+
+
 async def extract_text_from_url_async(url: str, session: aiohttp.ClientSession, use_jina: bool = False, 
                                     jina_api_key: Optional[str] = None, snippet: Optional[str] = None, 
                                     keep_links: bool = False) -> str:
@@ -527,7 +562,16 @@ async def extract_text_from_url_async(url: str, session: aiohttp.ClientSession, 
                 text = await extract_pdf_text_async(url, session)
                 return text[:10000]
 
-            async with session.get(url) as response:
+            async with session.get(url, headers=request_headers_for_url(url)) as response:
+                if response.status >= 400:
+                    return await fetch_with_requests_fallback(
+                        url,
+                        use_jina=use_jina,
+                        jina_api_key=jina_api_key,
+                        snippet=snippet,
+                        keep_links=keep_links,
+                    )
+
                 # 检测和处理编码
                 content_type = response.headers.get('content-type', '').lower()
                 if 'charset' in content_type:
@@ -546,8 +590,13 @@ async def extract_text_from_url_async(url: str, session: aiohttp.ClientSession, 
                 # has_error = len(html.split()) < 64
                 if has_error:
                     if WebParserClient_url is None:
-                        # If WebParserClient is not available, return error message
-                        return f"Error extracting content: {str(e)}"
+                        return await fetch_with_requests_fallback(
+                            url,
+                            use_jina=use_jina,
+                            jina_api_key=jina_api_key,
+                            snippet=snippet,
+                            keep_links=keep_links,
+                        )
                     # If content has error, use WebParserClient as fallback
                     client = WebParserClient(WebParserClient_url)
                     results = client.parse_urls([url])
@@ -596,8 +645,14 @@ async def extract_text_from_url_async(url: str, session: aiohttp.ClientSession, 
         else:
             return text[:50000]
 
-    except Exception as e:
-        return f"Error fetching {url}: {str(e)}"
+    except Exception:
+        return await fetch_with_requests_fallback(
+            url,
+            use_jina=use_jina,
+            jina_api_key=jina_api_key,
+            snippet=snippet,
+            keep_links=keep_links,
+        )
 
 async def fetch_page_content_async(urls: List[str], use_jina: bool = False, jina_api_key: Optional[str] = None, 
                                  snippets: Optional[Dict[str, str]] = None, show_progress: bool = False,

--- a/scripts/search/bing_search.py
+++ b/scripts/search/bing_search.py
@@ -30,13 +30,13 @@ headers = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
                   'AppleWebKit/537.36 (KHTML, like Gecko) '
                   'Chrome/58.0.3029.110 Safari/537.36',
-    'Referer': 'https://www.google.com/',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
     'Accept-Language': 'en-US,en;q=0.5',
     'Connection': 'keep-alive',
     'Upgrade-Insecure-Requests': '1'
 }
 
+DEFAULT_REFERER = 'https://www.google.com/'
 WIKIMEDIA_USER_AGENT = (
     'WebThinkerResearchBot/0.1 '
     '(https://github.com/RUC-NLPIR/WebThinker; academic research)'
@@ -48,7 +48,8 @@ def request_headers_for_url(url: str) -> Dict[str, str]:
     hostname = (urlparse(url).hostname or '').lower()
     if hostname.endswith(('.wikipedia.org', '.wikimedia.org', '.wikimediafoundation.org')):
         request_headers['User-Agent'] = WIKIMEDIA_USER_AGENT
-        request_headers.pop('Referer', None)
+    else:
+        request_headers['Referer'] = DEFAULT_REFERER
     return request_headers
 
 

--- a/scripts/tests/test_web_fetch_fallback.py
+++ b/scripts/tests/test_web_fetch_fallback.py
@@ -10,10 +10,13 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 from search.bing_search import (  # noqa: E402
+    DEFAULT_REFERER,
     WIKIMEDIA_USER_AGENT,
     extract_text_from_url_async,
     fetch_with_requests_fallback,
+    headers,
     request_headers_for_url,
+    session,
 )
 
 
@@ -24,11 +27,13 @@ class WebFetchFallbackTests(unittest.TestCase):
         )
         self.assertEqual(request_headers["User-Agent"], WIKIMEDIA_USER_AGENT)
         self.assertNotIn("Referer", request_headers)
+        self.assertNotIn("Referer", headers)
+        self.assertNotIn("Referer", session.headers)
 
     def test_other_domains_keep_existing_browser_headers(self):
         request_headers = request_headers_for_url("https://example.com/article")
         self.assertIn("Mozilla/5.0", request_headers["User-Agent"])
-        self.assertEqual(request_headers["Referer"], "https://www.google.com/")
+        self.assertEqual(request_headers["Referer"], DEFAULT_REFERER)
 
     def test_requests_fallback_runs_off_the_async_event_loop(self):
         import threading

--- a/scripts/tests/test_web_fetch_fallback.py
+++ b/scripts/tests/test_web_fetch_fallback.py
@@ -31,9 +31,17 @@ class WebFetchFallbackTests(unittest.TestCase):
         self.assertEqual(request_headers["Referer"], "https://www.google.com/")
 
     def test_requests_fallback_runs_off_the_async_event_loop(self):
+        import threading
+
+        main_thread = threading.current_thread()
+
+        def fake_fetch(*args, **kwargs):
+            self.assertNotEqual(threading.current_thread(), main_thread)
+            return "fallback page text"
+
         with patch(
             "search.bing_search.extract_text_from_url",
-            return_value="fallback page text",
+            side_effect=fake_fetch,
         ) as fetch:
             result = asyncio.run(
                 fetch_with_requests_fallback(

--- a/scripts/tests/test_web_fetch_fallback.py
+++ b/scripts/tests/test_web_fetch_fallback.py
@@ -1,0 +1,83 @@
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+
+SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from search.bing_search import (  # noqa: E402
+    WIKIMEDIA_USER_AGENT,
+    extract_text_from_url_async,
+    fetch_with_requests_fallback,
+    request_headers_for_url,
+)
+
+
+class WebFetchFallbackTests(unittest.TestCase):
+    def test_wikimedia_uses_descriptive_user_agent_without_google_referer(self):
+        request_headers = request_headers_for_url(
+            "https://en.wikipedia.org/wiki/Mercedes_Sosa"
+        )
+        self.assertEqual(request_headers["User-Agent"], WIKIMEDIA_USER_AGENT)
+        self.assertNotIn("Referer", request_headers)
+
+    def test_other_domains_keep_existing_browser_headers(self):
+        request_headers = request_headers_for_url("https://example.com/article")
+        self.assertIn("Mozilla/5.0", request_headers["User-Agent"])
+        self.assertEqual(request_headers["Referer"], "https://www.google.com/")
+
+    def test_requests_fallback_runs_off_the_async_event_loop(self):
+        with patch(
+            "search.bing_search.extract_text_from_url",
+            return_value="fallback page text",
+        ) as fetch:
+            result = asyncio.run(
+                fetch_with_requests_fallback(
+                    "https://example.com/article",
+                    snippet="relevant snippet",
+                )
+            )
+
+        self.assertEqual(result, "fallback page text")
+        fetch.assert_called_once_with(
+            "https://example.com/article",
+            False,
+            None,
+            "relevant snippet",
+            False,
+        )
+
+    def test_async_fetch_failure_uses_requests_fallback(self):
+        async def run_test():
+            session = Mock()
+            session.get.side_effect = asyncio.TimeoutError()
+
+            with patch(
+                "search.bing_search.fetch_with_requests_fallback",
+                new_callable=AsyncMock,
+                return_value="fallback page text",
+            ) as fallback:
+                result = await extract_text_from_url_async(
+                    "https://example.com/article",
+                    session,
+                    snippet="relevant snippet",
+                )
+
+            self.assertEqual(result, "fallback page text")
+            fallback.assert_awaited_once_with(
+                "https://example.com/article",
+                use_jina=False,
+                jina_api_key=None,
+                snippet="relevant snippet",
+                keep_links=False,
+            )
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`fetch_page_content_async` can fail on pages that remain reachable through the synchronous `requests` extractor. In the reproduced Wikipedia case, the aiohttp path timed out or received a blocked response while `requests` returned HTTP 200. When `WebParserClient_url` was not configured, the async path had no second retrieval channel and downstream code received only a search-result snippet. The short/empty-response branch also referenced an undefined exception variable.

## Changes

- Select request headers per URL and send a descriptive user agent to Wikimedia domains.
- Retry HTTP errors, short blocked responses, and async exceptions through the existing synchronous extractor.
- Run the synchronous fallback with `asyncio.to_thread` so it does not block the event loop.
- Replace the undefined exception reference with a deterministic empty/blocked-response message.
- Add focused tests for Wikimedia headers, ordinary-domain headers, off-event-loop execution, and async failure recovery.

The fallback is generic and contains no task-, domain-content-, or answer-specific logic.

## Verification

- `python -m unittest discover -s scripts/tests -p "test_*.py"`: 4 tests passed.
- Live smoke test against `https://en.wikipedia.org/wiki/Mercedes_Sosa`: retrieved 20,000 characters and found the expected `Studio albums` section and its 2000-2009 entries.
- The branch is based directly on the current upstream `main` revision (`db387eb`).

## Scope

This PR changes only `scripts/search/bing_search.py` and adds `scripts/tests/test_web_fetch_fallback.py`. It does not modify model prompts, search-query generation, API configuration, or answer logic.